### PR TITLE
feat: add chrome extension popup ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # ceshi
+
+该仓库包含一个用于 Chrome 插件弹出页的前端界面示例，位于 [`extension-ui/`](extension-ui/) 目录。
+
+## 预览方式
+
+直接在浏览器中打开 `extension-ui/index.html` 文件即可查看界面效果。若需作为插件弹出页使用，可在 Chrome 扩展程序的 `manifest.json` 中将该文件配置为 `action.default_popup`。
+
+## 主要特性
+
+- 💡 主题切换：支持亮色与暗色两种主题，并通过 `localStorage` 记忆用户选择。
+- ⏱️ 番茄钟：内置 25 分钟倒计时，支持开始、暂停与重置。
+- 📝 速记功能：允许添加、删除速记内容，并持久化到本地存储。
+- ⚙️ 设置开关：自定义常用插件偏好，同样支持本地存储记忆。
+
+所有交互逻辑位于 `extension-ui/script.js` 中，视觉样式定义在 `extension-ui/styles.css`。

--- a/extension-ui/index.html
+++ b/extension-ui/index.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>效率助理 - Chrome 插件面板</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="popup">
+      <header class="popup__header">
+        <div class="popup__brand">
+          <span class="popup__logo" aria-hidden="true">⚡</span>
+          <div>
+            <h1>效率助理</h1>
+            <p>快速组织一天的任务</p>
+          </div>
+        </div>
+        <button class="theme-toggle" id="themeToggle" aria-label="切换主题">
+          <span class="theme-toggle__icon">🌙</span>
+        </button>
+      </header>
+
+      <section class="card" aria-labelledby="quickActionsTitle">
+        <div class="card__header">
+          <h2 id="quickActionsTitle">快捷操作</h2>
+          <p>一键执行常用工作流</p>
+        </div>
+        <div class="quick-actions">
+          <button class="pill" data-action="focus">开始专注 25 分钟</button>
+          <button class="pill" data-action="break">提醒我休息</button>
+          <button class="pill" data-action="summary">生成每日总结</button>
+        </div>
+      </section>
+
+      <section class="card" aria-labelledby="focusSessionTitle">
+        <div class="card__header">
+          <h2 id="focusSessionTitle">专注计时</h2>
+          <p>番茄钟倒计时帮助你保持节奏</p>
+        </div>
+        <div class="focus">
+          <div class="focus__timer" id="focusTimer">25:00</div>
+          <div class="focus__controls">
+            <button class="btn" id="startFocus">开始</button>
+            <button class="btn btn--secondary" id="resetFocus">重置</button>
+          </div>
+          <p class="focus__hint" id="focusHint">点击“开始”启动新一轮专注。</p>
+        </div>
+      </section>
+
+      <section class="card" aria-labelledby="notesTitle">
+        <div class="card__header">
+          <h2 id="notesTitle">速记</h2>
+          <p>捕捉灵感与待办事项</p>
+        </div>
+        <form class="note-form" id="noteForm">
+          <label for="noteInput" class="sr-only">输入新的速记</label>
+          <input id="noteInput" type="text" placeholder="记录灵感或待办事项" required />
+          <button type="submit" class="btn">添加</button>
+        </form>
+        <ul class="note-list" id="noteList" aria-live="polite"></ul>
+      </section>
+
+      <section class="card" aria-labelledby="settingsTitle">
+        <div class="card__header">
+          <h2 id="settingsTitle">插件设置</h2>
+          <p>自定义工作方式</p>
+        </div>
+        <div class="settings">
+          <label class="setting">
+            <span>启动浏览器时自动开启专注模式</span>
+            <input type="checkbox" class="setting__input" id="autoFocus" />
+            <span class="setting__switch" aria-hidden="true"></span>
+          </label>
+          <label class="setting">
+            <span>启用通知提醒</span>
+            <input type="checkbox" class="setting__input" id="notifications" checked />
+            <span class="setting__switch" aria-hidden="true"></span>
+          </label>
+          <label class="setting">
+            <span>同步到云端</span>
+            <input type="checkbox" class="setting__input" id="sync" />
+            <span class="setting__switch" aria-hidden="true"></span>
+          </label>
+        </div>
+      </section>
+    </main>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/extension-ui/script.js
+++ b/extension-ui/script.js
@@ -1,0 +1,206 @@
+const focusDuration = 25 * 60;
+let remainingSeconds = focusDuration;
+let focusTimerInterval = null;
+
+const focusTimer = document.getElementById("focusTimer");
+const startFocusBtn = document.getElementById("startFocus");
+const resetFocusBtn = document.getElementById("resetFocus");
+const focusHint = document.getElementById("focusHint");
+const themeToggle = document.getElementById("themeToggle");
+const quickActionButtons = document.querySelectorAll(".pill");
+const noteForm = document.getElementById("noteForm");
+const noteInput = document.getElementById("noteInput");
+const noteList = document.getElementById("noteList");
+
+const STORAGE_KEYS = {
+  THEME: "extension-ui:theme",
+  NOTES: "extension-ui:notes",
+  SETTINGS: "extension-ui:settings",
+};
+
+function formatTime(seconds) {
+  const minutes = String(Math.floor(seconds / 60)).padStart(2, "0");
+  const secs = String(seconds % 60).padStart(2, "0");
+  return `${minutes}:${secs}`;
+}
+
+function updateTimerDisplay() {
+  focusTimer.textContent = formatTime(remainingSeconds);
+}
+
+function setTimerHint(text, status = "idle") {
+  focusHint.textContent = text;
+  focusHint.dataset.status = status;
+}
+
+function stopTimer() {
+  if (focusTimerInterval) {
+    clearInterval(focusTimerInterval);
+    focusTimerInterval = null;
+  }
+}
+
+function startFocusSession() {
+  if (focusTimerInterval) return;
+  const endTime = Date.now() + remainingSeconds * 1000;
+  setTimerHint("保持专注，加油！", "running");
+  startFocusBtn.textContent = "暂停";
+
+  focusTimerInterval = setInterval(() => {
+    const diff = Math.round((endTime - Date.now()) / 1000);
+    remainingSeconds = Math.max(diff, 0);
+    updateTimerDisplay();
+
+    if (remainingSeconds === 0) {
+      stopTimer();
+      startFocusBtn.textContent = "开始";
+      setTimerHint("时间到！记得奖励自己一次休息。", "complete");
+      remainingSeconds = focusDuration;
+      updateTimerDisplay();
+    }
+  }, 1000);
+}
+
+function pauseFocusSession() {
+  stopTimer();
+  setTimerHint("已暂停。点击开始继续。", "paused");
+  startFocusBtn.textContent = "开始";
+}
+
+startFocusBtn.addEventListener("click", () => {
+  if (focusTimerInterval) {
+    pauseFocusSession();
+  } else {
+    startFocusSession();
+  }
+});
+
+resetFocusBtn.addEventListener("click", () => {
+  stopTimer();
+  remainingSeconds = focusDuration;
+  updateTimerDisplay();
+  setTimerHint("点击“开始”启动新一轮专注。", "idle");
+  startFocusBtn.textContent = "开始";
+});
+
+function applyTheme(theme) {
+  document.body.classList.toggle("dark", theme === "dark");
+  const icon = theme === "dark" ? "☀️" : "🌙";
+  themeToggle.querySelector(".theme-toggle__icon").textContent = icon;
+  localStorage.setItem(STORAGE_KEYS.THEME, theme);
+}
+
+function toggleTheme() {
+  const isDark = document.body.classList.contains("dark");
+  applyTheme(isDark ? "light" : "dark");
+}
+
+themeToggle.addEventListener("click", toggleTheme);
+
+(function initializeTheme() {
+  const savedTheme = localStorage.getItem(STORAGE_KEYS.THEME);
+  if (savedTheme === "dark") {
+    applyTheme("dark");
+  }
+})();
+
+function renderNotes(notes) {
+  noteList.innerHTML = "";
+  notes.forEach((note, index) => {
+    const item = document.createElement("li");
+    item.className = "note";
+
+    const text = document.createElement("span");
+    text.className = "note__text";
+    text.textContent = note;
+
+    const delBtn = document.createElement("button");
+    delBtn.className = "note__delete";
+    delBtn.type = "button";
+    delBtn.setAttribute("aria-label", `删除速记 ${index + 1}`);
+    delBtn.innerHTML = "&times;";
+    delBtn.addEventListener("click", () => {
+      notes.splice(index, 1);
+      localStorage.setItem(STORAGE_KEYS.NOTES, JSON.stringify(notes));
+      renderNotes(notes);
+    });
+
+    item.appendChild(text);
+    item.appendChild(delBtn);
+    noteList.appendChild(item);
+  });
+}
+
+function loadNotes() {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEYS.NOTES);
+    return stored ? JSON.parse(stored) : [];
+  } catch (error) {
+    console.warn("无法解析存储的笔记，将清空。");
+    localStorage.removeItem(STORAGE_KEYS.NOTES);
+    return [];
+  }
+}
+
+const notes = loadNotes();
+renderNotes(notes);
+
+noteForm.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const value = noteInput.value.trim();
+  if (!value) return;
+  notes.unshift(value);
+  localStorage.setItem(STORAGE_KEYS.NOTES, JSON.stringify(notes));
+  renderNotes(notes);
+  noteForm.reset();
+});
+
+quickActionButtons.forEach((button) => {
+  button.addEventListener("click", () => {
+    const action = button.dataset.action;
+    switch (action) {
+      case "focus":
+        setTimerHint("已准备好，点击开始立即进入专注。");
+        break;
+      case "break":
+        setTimerHint("稍后记得起身走动，喝杯水放松一下！");
+        break;
+      case "summary":
+        setTimerHint("总结提示：回顾今日完成的 3 件事，并计划明天的重点。");
+        break;
+      default:
+        break;
+    }
+    button.classList.add("pill--active");
+    setTimeout(() => button.classList.remove("pill--active"), 800);
+  });
+});
+
+(function restoreSettings() {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEYS.SETTINGS);
+    if (!stored) return;
+    const settings = JSON.parse(stored);
+    Object.entries(settings).forEach(([id, value]) => {
+      const input = document.getElementById(id);
+      if (input) {
+        input.checked = Boolean(value);
+      }
+    });
+  } catch (error) {
+    console.warn("无法解析设置，将使用默认值。");
+  }
+})();
+
+const settingInputs = document.querySelectorAll(".setting__input");
+settingInputs.forEach((input) => {
+  input.addEventListener("change", () => {
+    const settings = Array.from(settingInputs).reduce((acc, item) => {
+      acc[item.id] = item.checked;
+      return acc;
+    }, {});
+    localStorage.setItem(STORAGE_KEYS.SETTINGS, JSON.stringify(settings));
+  });
+});
+
+updateTimerDisplay();

--- a/extension-ui/styles.css
+++ b/extension-ui/styles.css
@@ -1,0 +1,319 @@
+:root {
+  color-scheme: light dark;
+  --color-bg: #f4f6fb;
+  --color-card: #ffffff;
+  --color-text: #1f2933;
+  --color-subtle: #6b7280;
+  --color-primary: #2563eb;
+  --color-primary-soft: rgba(37, 99, 235, 0.12);
+  --color-border: #e5e7eb;
+  --shadow: 0 16px 32px rgba(15, 23, 42, 0.12);
+}
+
+body.dark {
+  --color-bg: #101320;
+  --color-card: #161b2f;
+  --color-text: #f8fafc;
+  --color-subtle: #94a3b8;
+  --color-primary: #60a5fa;
+  --color-primary-soft: rgba(96, 165, 250, 0.18);
+  --color-border: rgba(148, 163, 184, 0.24);
+  --shadow: 0 18px 40px rgba(13, 16, 28, 0.45);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "PingFang SC", "Microsoft YaHei", sans-serif;
+  background: radial-gradient(circle at top, rgba(37, 99, 235, 0.18), transparent 55%),
+    var(--color-bg);
+  color: var(--color-text);
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 32px 16px;
+}
+
+.popup {
+  width: min(360px, 100%);
+  background: var(--color-card);
+  border-radius: 20px;
+  box-shadow: var(--shadow);
+  padding: 24px;
+  display: grid;
+  gap: 20px;
+}
+
+.popup__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.popup__brand {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.popup__logo {
+  font-size: 1.9rem;
+}
+
+.popup__brand h1 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.popup__brand p {
+  margin: 4px 0 0;
+  color: var(--color-subtle);
+  font-size: 0.85rem;
+}
+
+.theme-toggle {
+  border: none;
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(37, 99, 235, 0.35);
+}
+
+.card {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.03), transparent);
+  border: 1px solid var(--color-border);
+  border-radius: 16px;
+  padding: 18px;
+  display: grid;
+  gap: 14px;
+}
+
+.card__header h2 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.card__header p {
+  margin: 4px 0 0;
+  font-size: 0.85rem;
+  color: var(--color-subtle);
+}
+
+.quick-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.pill {
+  border: none;
+  padding: 10px 14px;
+  border-radius: 999px;
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.pill:hover,
+.pill:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(37, 99, 235, 0.25);
+}
+
+.pill--active {
+  transform: translateY(-1px) scale(0.98);
+  box-shadow: inset 0 0 0 1px var(--color-primary);
+}
+
+.focus {
+  display: grid;
+  gap: 12px;
+  text-align: center;
+}
+
+.focus__timer {
+  font-size: 2.6rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+}
+
+.focus__controls {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+}
+
+.btn {
+  border: none;
+  border-radius: 12px;
+  background: var(--color-primary);
+  color: #fff;
+  padding: 10px 18px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.btn:hover,
+.btn:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 22px rgba(37, 99, 235, 0.35);
+}
+
+.btn--secondary {
+  background: transparent;
+  color: var(--color-primary);
+  border: 1px solid var(--color-primary);
+}
+
+.focus__hint {
+  margin: 0;
+  color: var(--color-subtle);
+  font-size: 0.85rem;
+}
+
+.note-form {
+  display: flex;
+  gap: 10px;
+}
+
+.note-form input {
+  flex: 1;
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.7);
+  color: inherit;
+}
+
+body.dark .note-form input {
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.note-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+  max-height: 140px;
+  overflow-y: auto;
+}
+
+.note {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--color-primary);
+  padding: 10px 12px;
+  border-radius: 10px;
+  font-size: 0.9rem;
+}
+
+.note__text {
+  flex: 1;
+  margin-right: 12px;
+}
+
+.note__delete {
+  border: none;
+  background: transparent;
+  color: var(--color-primary);
+  cursor: pointer;
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.settings {
+  display: grid;
+  gap: 12px;
+}
+
+.setting {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(37, 99, 235, 0.05);
+}
+
+.setting span:first-child {
+  font-size: 0.95rem;
+}
+
+.setting__input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.setting__switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.6);
+  position: relative;
+  transition: background 0.2s ease;
+}
+
+.setting__switch::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 4px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.2);
+  transition: transform 0.2s ease;
+}
+
+.setting__input:checked + .setting__switch {
+  background: var(--color-primary);
+}
+
+.setting__input:checked + .setting__switch::after {
+  transform: translateX(18px);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 420px) {
+  body {
+    padding: 24px 12px;
+  }
+
+  .popup {
+    padding: 20px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a Chrome 扩展弹出页示例，包含快捷操作、番茄钟、速记和设置区块
- 创建对应的样式表，提供亮暗主题、卡片式布局与交互状态
- 实现主题切换、番茄钟计时、本地存储的速记与设置交互逻辑

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e4e6cde8f0832bbea39361f0538f4c